### PR TITLE
chore: add .yamllint.yml with custom rule disables

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,6 @@
+extends: default
+
+rules:
+  document-start: disable
+  truthy: disable
+  line-length: disable


### PR DESCRIPTION
Add a new .yamllint.yml configuration file extending the default ruleset.

The following rules are disabled:
- document-start
- truthy
- line-length

These rules are not necessary for our use case.

This shall resolve the CI issue in https://github.com/KORComic/docs/pull/5

Change-Id: 07648012a6df2e46fd7b46ac9ee3eba9
Change-Id-Short: zstvrzyxptmk